### PR TITLE
Ability to change month

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/mock-server/src/controllers/expenses.controller.ts
+++ b/mock-server/src/controllers/expenses.controller.ts
@@ -3,8 +3,16 @@ import { AddExpenseParams } from '../models/add-expense-params.model';
 import { ControllerBase } from './controller-base';
 
 export class ExpensesController extends ControllerBase {
-  public getExpenses = (_: Request, res: Response) => {
-    res.send(this.wrapData(this.dataContext.exchangedExpenses));
+  public getExpenses = (req: Request, res: Response) => {
+    const month = req.query['month'];
+    const year = req.query['year'];
+    if (month && year) {
+      res.send(this.wrapData(this.dataContext.exchangedExpenses.filter((e) =>
+        e.date.getMonth() + 1 == Number(month) && e.date.getFullYear() == Number(year)
+      )));
+    } else {
+      res.sendStatus(500);
+    }
   }
 
   public addNewExpense = (req: Request<AddExpenseParams>, res: Response) => {
@@ -18,7 +26,7 @@ export class ExpensesController extends ControllerBase {
     );
     const newExpense = {
       id: maxId + 1,
-      date: req.body.date,
+      date: new Date(req.body.date),
       item: req.body.item,
       price: {
         amount: req.body.priceAmount,

--- a/src/app/http-clients/expenses-http-client.service.ts
+++ b/src/app/http-clients/expenses-http-client.service.ts
@@ -2,6 +2,7 @@ import { Expense } from '@app/models/expense.model';
 import { Injectable } from '@angular/core';
 import { BaseHttpClientService } from './base-http-client.service';
 import { AddExpenseParams } from './expenses-http-client.model';
+import { Month } from '@app/models/month.model';
 
 @Injectable({
   providedIn: 'root'
@@ -10,8 +11,11 @@ export class ExpensesHttpClientService {
 
   constructor(private baseHttpClient: BaseHttpClientService) { }
 
-  getAllExpenses() {
-    return this.baseHttpClient.get<Expense[]>('expenses');
+  getAllExpenses(selectedMonth: Month) {
+    return this.baseHttpClient.get<Expense[]>('expenses', {
+      "month": selectedMonth.month,
+      "year": selectedMonth.year
+    });
   }
 
   addNewExpense(expense: AddExpenseParams) {

--- a/src/app/models/month.model.ts
+++ b/src/app/models/month.model.ts
@@ -1,0 +1,4 @@
+export interface Month {
+  month: number,
+  year: number
+}

--- a/src/app/modules/expenses/expenses.resolver.ts
+++ b/src/app/modules/expenses/expenses.resolver.ts
@@ -1,19 +1,19 @@
 import { ExpensesHttpClientService } from './../../http-clients/expenses-http-client.service';
 import { Injectable } from '@angular/core';
-import {
-  Router, Resolve,
+import { Resolve,
   RouterStateSnapshot,
   ActivatedRouteSnapshot
 } from '@angular/router';
 import { Expense } from '@app/models/expense.model';
-import { Observable, of } from 'rxjs';
+import { ExpensesMonthService } from '@app/services/expenses-month.service';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ExpensesResolver implements Resolve<Expense[]> {
-  constructor(private expensesHttpClient: ExpensesHttpClientService) {}
+  constructor(private expensesHttpClient: ExpensesHttpClientService, private expensesMonthService: ExpensesMonthService) {}
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Expense[]>  {
-    return this.expensesHttpClient.getAllExpenses();
+    return this.expensesHttpClient.getAllExpenses(this.expensesMonthService.month);
   }
 }

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between">
   <ngb-datepicker class="datepicker">
     <ng-template ngbDatepickerContent>
-      <div class="bg-light datepicker-align-fix"></div>
+      <div class="bg-light datepicker-content"></div>
     </ng-template>
   </ngb-datepicker>
   <button type="button" class="btn btn-primary" (click)="open(addNewExpenses)">Add new expense</button>

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-between">
-  <ngb-datepicker class="datepicker">
+  <ngb-datepicker class="datepicker" [startDate]="selectedMonth" (navigate)="onMonthChange($event)">
     <ng-template ngbDatepickerContent>
       <div class="bg-light datepicker-content"></div>
     </ng-template>

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
@@ -21,7 +21,3 @@
         <button type="button" class="btn btn-success" [disabled]="addNewExpensesForm.form.invalid" (click)="modal.close(addNewExpensesForm.form.value)">Save</button>
     </div>
 </ng-template>
-
-<ng-template #month let-dp>
-
-</ng-template>

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.html
@@ -1,4 +1,11 @@
-<button type="button" class="btn btn-primary" (click)="open(addNewExpenses)">Add new expense</button>
+<div class="d-flex justify-content-between">
+  <ngb-datepicker class="datepicker">
+    <ng-template ngbDatepickerContent>
+      <div class="bg-light datepicker-align-fix"></div>
+    </ng-template>
+  </ngb-datepicker>
+  <button type="button" class="btn btn-primary" (click)="open(addNewExpenses)">Add new expense</button>
+</div>
 <app-expenses-table [data]="expenses"></app-expenses-table>
 
 <ng-template #addNewExpenses let-modal>
@@ -13,4 +20,8 @@
         <button type="button" class="btn btn-outline-dark" (click)="modal.dismiss()">Cancel</button>
         <button type="button" class="btn btn-success" [disabled]="addNewExpensesForm.form.invalid" (click)="modal.close(addNewExpensesForm.form.value)">Save</button>
     </div>
+</ng-template>
+
+<ng-template #month let-dp>
+
 </ng-template>

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.scss
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.scss
@@ -2,6 +2,6 @@
   width: 250px;
 }
 
-.datepicker-align-fix {
+.datepicker-content {
   height: 4px;
 }

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.scss
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.scss
@@ -1,0 +1,7 @@
+.datepicker {
+  width: 250px;
+}
+
+.datepicker-align-fix {
+  height: 4px;
+}

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
@@ -9,15 +9,16 @@ import { AddExpenseParams } from '@app/http-clients/expenses-http-client.model';
 
 @Component({
   selector: 'app-expenses-page',
-  templateUrl: './expenses-page.component.html'
+  templateUrl: './expenses-page.component.html',
+  styleUrls: ['./expenses-page.component.scss']
 })
 export class ExpensesPageComponent implements OnInit {
 
   expenses: Expense[];
 
   constructor(
-    private route: ActivatedRoute, 
-    private currencyService: CurrencyService, 
+    private route: ActivatedRoute,
+    private currencyService: CurrencyService,
     private expensesHttpClient: ExpensesHttpClientService,
     private modalService: NgbModal) { }
 
@@ -25,7 +26,7 @@ export class ExpensesPageComponent implements OnInit {
     this.route.data.subscribe((data) => this.expenses = data.expenses ?? []);
     this.currencyService.mainCurrency$
       .pipe(
-        //we need to skip first item emitted by BehaviorSubject because we already get initial data from route resolver 
+        //we need to skip first item emitted by BehaviorSubject because we already get initial data from route resolver
         skip(1),
         switchMap(() => this.expensesHttpClient.getAllExpenses()))
       .subscribe((expenses) => this.expenses = expenses);

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
@@ -1,11 +1,13 @@
+import { ExpensesMonthService } from './../../../../services/expenses-month.service';
 import { ExpensesHttpClientService } from '@http-clients/expenses-http-client.service';
 import { CurrencyService } from '@services/currency.service';
 import { Expense } from '@app/models/expense.model';
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { switchMap, skip } from 'rxjs/operators';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDate, NgbDatepickerNavigateEvent, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AddExpenseParams } from '@app/http-clients/expenses-http-client.model';
+import { Month } from '@app/models/month.model';
 
 @Component({
   selector: 'app-expenses-page',
@@ -15,21 +17,31 @@ import { AddExpenseParams } from '@app/http-clients/expenses-http-client.model';
 export class ExpensesPageComponent implements OnInit {
 
   expenses: Expense[];
+  selectedMonth: Month;
 
   constructor(
     private route: ActivatedRoute,
     private currencyService: CurrencyService,
     private expensesHttpClient: ExpensesHttpClientService,
-    private modalService: NgbModal) { }
+    private modalService: NgbModal,
+    private expensesMonthService: ExpensesMonthService) { }
 
   ngOnInit(): void {
+    this.selectedMonth = this.expensesMonthService.getMonth();
     this.route.data.subscribe((data) => this.expenses = data.expenses ?? []);
     this.currencyService.mainCurrency$
       .pipe(
         //we need to skip first item emitted by BehaviorSubject because we already get initial data from route resolver
         skip(1),
-        switchMap(() => this.expensesHttpClient.getAllExpenses()))
+        switchMap(() => this.expensesHttpClient.getAllExpenses(this.expensesMonthService.month)))
       .subscribe((expenses) => this.expenses = expenses);
+    this.expensesMonthService.month$
+      .pipe(
+        //we need to skip first item emitted by BehaviorSubject because we already get initial data from route resolver
+        skip(1),
+        switchMap(() => this.expensesHttpClient.getAllExpenses(this.expensesMonthService.month)))
+      .subscribe((expenses) => this.expenses = expenses);
+
   }
 
   addNewExpense(expense: AddExpenseParams) {
@@ -46,6 +58,13 @@ export class ExpensesPageComponent implements OnInit {
         date: new Date(date.year, date.month - 1, date.day),
         ...restParams
       });
+    });
+  }
+
+  onMonthChange(value: NgbDatepickerNavigateEvent) {
+    this.expensesMonthService.month$.next({
+      month: value.next.month,
+      year: value.next.year
     });
   }
 }

--- a/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
+++ b/src/app/modules/expenses/pages/expenses-page/expenses-page.component.ts
@@ -41,13 +41,16 @@ export class ExpensesPageComponent implements OnInit {
         skip(1),
         switchMap(() => this.expensesHttpClient.getAllExpenses(this.expensesMonthService.month)))
       .subscribe((expenses) => this.expenses = expenses);
-
   }
 
   addNewExpense(expense: AddExpenseParams) {
     this.expensesHttpClient.addNewExpense(expense)
       .subscribe((addedExpanse) => {
-        this.expenses.push(addedExpanse);
+        const date = new Date(addedExpanse.date)
+        if (this.expensesMonthService.month.month == date.getMonth() + 1
+          && this.expensesMonthService.month.year == date.getFullYear()) {
+            this.expenses.push(addedExpanse);
+          }
       });
   }
 

--- a/src/app/services/expenses-month.service.ts
+++ b/src/app/services/expenses-month.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, forkJoin } from 'rxjs';
+import { Month } from '@app/models/month.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ExpensesMonthService {
+  selectedMonthStorageName = "selected-month";
+  month$: BehaviorSubject<Month>;
+  get month() {
+    return this.month$.value;
+  }
+
+  constructor() {
+    this.month$ = new BehaviorSubject<Month>(this.getMonth());
+    this.month$.subscribe((value) => this.saveMonth(value));
+  }
+
+  getMonth(): Month {
+    const selectedMonth = localStorage.getItem(this.selectedMonthStorageName);
+    const currentDate = new Date();
+    return selectedMonth ? JSON.parse(selectedMonth) : {
+      month: currentDate.getMonth(),
+      year: currentDate.getFullYear()
+    };
+  }
+
+  saveMonth(selectedMonth: Month) {
+    localStorage.setItem(this.selectedMonthStorageName, JSON.stringify(selectedMonth));
+  }
+}


### PR DESCRIPTION
## Description of fix

- added new service to store month. `Month` model contains `month` and `year`
- implemented date picker to select month at the top of the page; button to add new expense was moved to right
- corrected `Mock Server`'s logic to be able to filter expenses by month and year