### PR TITLE
Dialog "Add new expense" must have "Date" input filled with selected month/year pair

### DIFF
--- a/src/app/modules/expenses/components/add-new-expense-form/add-new-expense-form.component.ts
+++ b/src/app/modules/expenses/components/add-new-expense-form/add-new-expense-form.component.ts
@@ -1,8 +1,10 @@
 import { NgbDate } from '@ng-bootstrap/ng-bootstrap';
 import { CurrencyService } from '@services/currency.service';
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Currency } from '@app/models/currency.model';
+import { ExpensesMonthService } from '@app/services/expenses-month.service';
+import { Month } from '@app/models/month.model';
 
 @Component({
   selector: 'app-add-new-expense-form',
@@ -11,24 +13,26 @@ import { Currency } from '@app/models/currency.model';
 })
 export class AddNewExpenseComponent implements OnInit {
   private defaultCurrencyIdStorageName = 'default-currency';
-  currencies: Currency[]
-  form = this.fb.group({
-    'date': [this.currentDate, Validators.required],
-    'item': [null, Validators.required],
-    'priceAmount': [null, Validators.required],
-    'currencyId': [this.defaultCurrency, Validators.required]
-  });
-  get currentDate(): NgbDate {
-    const now = new Date();
-    return new NgbDate(now.getFullYear(), now.getMonth() + 1, now.getDate());
-  }
+  currencies: Currency[];
+  form: FormGroup;
+
   get defaultCurrency(): number {
     const currencyId = localStorage.getItem(this.defaultCurrencyIdStorageName);
     return currencyId ? Number(currencyId) : 0;
   }
 
-  constructor(private fb: FormBuilder, currency: CurrencyService) {
+  constructor(
+    private fb: FormBuilder,
+    currency: CurrencyService,
+    expensesMonthService: ExpensesMonthService) {
     this.currencies = currency.currencies;
+
+    this.form = this.fb.group({
+      'date': [this.getCurrentDate(expensesMonthService.month), Validators.required],
+      'item': [null, Validators.required],
+      'priceAmount': [null, Validators.required],
+      'currencyId': [this.defaultCurrency, Validators.required]
+    });
   }
 
   ngOnInit(): void {
@@ -37,5 +41,11 @@ export class AddNewExpenseComponent implements OnInit {
         localStorage.setItem(this.defaultCurrencyIdStorageName, String(value));
       }
     });
+  }
+
+  getCurrentDate(month: Month): NgbDate {
+    const currentDay = new Date().getDate();
+    const daysInMonth = new Date(month.year, month.month, 0).getDate();
+    return new NgbDate(month.year, month.month, currentDay > daysInMonth ? daysInMonth : currentDay);
   }
 }


### PR DESCRIPTION
## Description of issue

Input field `Date` in dialog `Add new expense` must be filled with respective `month/year` which was selected on expenses page 

## Description of fix

- implemented logic to set month and year in date for field `Date`, the number of the day keeps unchanged
- when selected month doesn't have number of current day: maximum day for the month is used then