### PR TITLE
Fixed size for expenses table columns

### DIFF
--- a/src/app/components/price/price.component.html
+++ b/src/app/components/price/price.component.html
@@ -1,4 +1,4 @@
-<div [ngbPopover]="exchangedPrice ? popoverContent : null" triggers="mouseenter:mouseleave">
+<div [ngbPopover]="exchangedPrice ? popoverContent : null" triggers="mouseenter:mouseleave" class="price-container">
     <span>
         {{ price.amount | number : '1.0-2' }}
     </span>

--- a/src/app/components/price/price.component.scss
+++ b/src/app/components/price/price.component.scss
@@ -1,3 +1,7 @@
 .currency-name {
-    color: #00000050;
+  color: #00000050;
+}
+
+.price-container {
+  white-space: nowrap;
 }

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -1,13 +1,13 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th 
-                scope="col" 
-                [sortable]="column.name" 
-                [direction]="defaultSorting.column === column.name ? defaultSorting.direction : ''" 
-                (sort)="onSort($event)" 
+            <th
+                scope="col"
+                [sortable]="column.name"
+                [direction]="defaultSorting.column === column.name ? defaultSorting.direction : ''"
+                (sort)="onSort($event)"
                 *ngFor="let column of columns"
-            >
+                [ngStyle]="{ 'min-width': column.minWidth, 'width': column.stretch ? '100%' : null }">
                 <span>{{ column.displayName }}</span>
             </th>
         </tr>

--- a/src/app/components/table/table.model.ts
+++ b/src/app/components/table/table.model.ts
@@ -3,6 +3,8 @@ import { TemplateRef } from "@angular/core";
 export interface TableColumn<T> {
     name: string,
     displayName: string,
+    minWidth?: string,
+    stretch?: boolean,
     function?: (row: T) => string,
     template?: () => TemplateRef<unknown>;
     sortFunc?: (first: T, second: T) => number;

--- a/src/app/modules/expenses/components/expenses-table/expenses-table.component.ts
+++ b/src/app/modules/expenses/components/expenses-table/expenses-table.component.ts
@@ -21,11 +21,13 @@ export class ExpensesTableComponent {
     },
     {
       name: 'item',
-      displayName: 'Item(s)'
+      displayName: 'Item(s)',
+      stretch: true
     },
     {
       name: 'price',
       displayName: 'Price',
+      minWidth: '100px',
       template: () => this.price,
       sortFunc: priceComparer
     }


### PR DESCRIPTION
### Description of issue

Need to make column `item` be stretched

### Description of fix

- added new properties in `TableColumn`:
  - `minWidth` - minimal width for column
  - `stretch` - makes column be stretched
- made column `item` be stretched
- set min width `100px` for column `price`