### PR TITLE
Version of mock-server is not submitted to git

### DIFF
--- a/.github/workflows/create-app-label.yml
+++ b/.github/workflows/create-app-label.yml
@@ -1,5 +1,7 @@
 name: Create App Version Label
 
+concurrency: versioning
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/create-mockserver-label.yml
+++ b/.github/workflows/create-mockserver-label.yml
@@ -1,5 +1,7 @@
 name: Create MockServer Version Label
 
+concurrency: versioning
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
### Description of issue

Sometimes version of `mock-server` or `application` is not submitted to `master` and the commit remains unattached with warning:

```
This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.
```

### Description of fix

Best fix for the issue in this particular case is implementing some logic to prevent running version related workflows simultaneously. Git has feature called `concurrency` which allows to specify concurrency group and run workflows from the group one by one.