### PR TITLE
Autocomplete list for "item" control must be empty if there is no text in the control

### DIFF
--- a/mock-server/src/controllers/controller-base.ts
+++ b/mock-server/src/controllers/controller-base.ts
@@ -3,7 +3,7 @@ import { DataContext } from '../data/data-context';
 export abstract class ControllerBase {
   constructor(protected dataContext: DataContext) {}
 
-  protected wrapData(data: unknown) {
+  protected wrapData<T>(data: T) {
     return {
       data
     }

--- a/mock-server/src/controllers/expenses.controller.ts
+++ b/mock-server/src/controllers/expenses.controller.ts
@@ -5,6 +5,7 @@ import { ControllerBase } from './controller-base';
 import { DataContext } from '../data/data-context';
 import { Expense } from '../models/expense.model';
 import FuzzySearch from 'fuzzy-search';
+import { ItemWithCategory } from '../models/item-with-category.model';
 
 export class ExpensesController extends ControllerBase {
 
@@ -75,11 +76,16 @@ export class ExpensesController extends ControllerBase {
   }
 
   public getExistingItems = (req: Request<unknown, unknown, string>, res: Response) => {
-    res.send(this.wrapData(
-      this.itemsSearcher
-        .search(req.body)
-        .filter((v, i, s) => s.findIndex(o => o.item === v.item) === i)
-        .map((e) => ({ item: e.item, categoryId: e.category?.id}))));
+    let result: ItemWithCategory[] = [];
+
+    if (req.body != null && req.body.length > 0) {
+      result = this.itemsSearcher
+      .search(req.body)
+      .filter((v, i, s) => s.findIndex(o => o.item === v.item) === i)
+      .map((e) => ({ item: e.item, categoryId: e.category?.id}));
+    }
+
+    res.send(this.wrapData(result));
   }
 
   public removeExpense = (req: Request, res: Response) => {

--- a/mock-server/src/models/item-with-category.model.ts
+++ b/mock-server/src/models/item-with-category.model.ts
@@ -1,0 +1,4 @@
+export interface ItemWithCategory {
+  item: string;
+  categoryId?: number;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "money-management",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "money-management",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@angular/animations": "^14.1.2",
         "@angular/common": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-management",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/http-clients/expenses-http-client.service.ts
+++ b/src/app/http-clients/expenses-http-client.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { BaseHttpClientService } from './base-http-client.service';
 import { AddExpenseParams, ItemWithCategory } from './expenses-http-client.model';
 import { Month } from '@app/models/month.model';
+import { of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -23,6 +24,10 @@ export class ExpensesHttpClientService {
   }
 
   getExistingItems(searchEntry: string) {
+    if (searchEntry == null || searchEntry.length === 0) {
+      return of([]);
+    }
+
     return this.baseHttpClient.post<ItemWithCategory[]>('expenses/items', searchEntry, undefined, {
       'Content-Type': 'text/plain'
     })


### PR DESCRIPTION
### Description of issue

Endpoint `/expenses/items` returns all existing items if it takes empty or nullable string, need to return empty array in such cases

### Description of fix

- implemented logic to check search string in endpoint `/expenses/items` and return empty array if it's null or empty
- also implemented logic on FE side to prevent making extra call with emtpy/null string