### PR TITLE
Restored git push in "Create Version Label" workflow

### DIFF
--- a/.github/workflows/create-label.yml
+++ b/.github/workflows/create-label.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           git config --global user.name "$env:GITHUB_ACTOR"
           git config --global user.email "$env:GITHUB_ACTOR@users.noreply.github.com"
+          git pull
           git commit -am "[automated] Bumped ${{ inputs.app-name }} version to ${{ env.new-version }} [skip ci]"
           if ("${{ inputs.skip-tag }}" -eq "false") { git tag v${{ env.new-version }} }
           git push


### PR DESCRIPTION
Put `git push` before commiting changes related to new version to avoid extraneous merge commit