### PR TITLE
Incorrect date is set when user edit item

### DIFF
--- a/src/app/modules/expenses/components/expense-form/expense-form.component.ts
+++ b/src/app/modules/expenses/components/expense-form/expense-form.component.ts
@@ -102,7 +102,7 @@ export class ExpenseFormComponent implements OnInit {
 
     this.form.patchValue({
       id: item.id,
-      date: new NgbDate(item.date.getFullYear(), item.date.getMonth() + 1, item.date.getDay()),
+      date: new NgbDate(item.date.getFullYear(), item.date.getMonth() + 1, item.date.getDate()),
       item: item.item,
       priceAmount: item.price.amount,
       currencyId: item.price.currency.id,


### PR DESCRIPTION
### Description of issue

The issue occurs due to incorrect method used to get day from date in method `populateValues`

### Description of fix

I replaced method `getDay` with `getDate` because `getDay` returns day of the week number